### PR TITLE
Adding a DSN configuration screenshot example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ This plugin enable Mautic 5 to run Sparkpost as a transport.
 - port: Your Sparkpost port
 - options:
   - region: Your Sparkpost region
+
+<img width="1105" alt="Screenshot 2023-08-07 at 12 57 39" src="https://github.com/escopecz/sparkpost-plugin/assets/1235442/acb8b5fc-6315-4ca7-a9ba-ec9822eb8eb4">


### PR DESCRIPTION
I think that a screenshot will help a lot for users to fill in the region and the "default" host. See https://github.com/escopecz/sparkpost-plugin/tree/screenshot#mautic-mailer-dsn-example for preview.